### PR TITLE
Create GetLimts() to return ratelimit values set in Sia

### DIFF
--- a/ratelimit.go
+++ b/ratelimit.go
@@ -72,8 +72,8 @@ func NewRLConn(conn net.Conn, rl *RateLimit, cancel <-chan struct{}) net.Conn {
 }
 
 // GetLimits gets the current limits for the global rate limiter.
-func (rl *RateLimit) GetLimits() (int64, int64) {
-	return rl.atomicReadBPS, rl.atomicWriteBPS
+func (rl *RateLimit) GetLimits() (int64, int64, uint64) {
+	return atomic.LoadInt64(&rl.atomicReadBPS), atomic.LoadInt64(&rl.atomicWriteBPS), atomic.LoadUint64(&rl.atomicPacketSize)
 }
 
 // SetLimits sets new limits for the global rate limiter.

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -71,9 +71,12 @@ func NewRLConn(conn net.Conn, rl *RateLimit, cancel <-chan struct{}) net.Conn {
 	}
 }
 
-// GetLimits gets the current limits for the global rate limiter.
-func (rl *RateLimit) GetLimits() (int64, int64, uint64) {
-	return atomic.LoadInt64(&rl.atomicReadBPS), atomic.LoadInt64(&rl.atomicWriteBPS), atomic.LoadUint64(&rl.atomicPacketSize)
+// Limits gets the current limits for the global rate limiter.
+func (rl *RateLimit) Limits() (int64, int64, uint64) {
+	readBPS := atomic.LoadInt64(&rl.atomicReadBPS)
+	writeBPS := atomic.LoadInt64(&rl.atomicWriteBPS)
+	packetSize := atomic.LoadUint64(&rl.atomicPacketSize)
+	return readBPS, writeBPS, packetSize
 }
 
 // SetLimits sets new limits for the global rate limiter.

--- a/ratelimit.go
+++ b/ratelimit.go
@@ -10,7 +10,7 @@ import (
 )
 
 type (
-	// rateLimit declares the global rate limit for read and write operations
+	// RateLimit declares the global rate limit for read and write operations
 	// on a io.ReadWriter. Whenever a caller wants to read or write, they have
 	// to wait until readBlock/writeBlock to start the actual read or write
 	// operation. Each caller also pushes these timestamps into the future to
@@ -69,6 +69,11 @@ func NewRLConn(conn net.Conn, rl *RateLimit, cancel <-chan struct{}) net.Conn {
 			cancel:     cancel,
 		},
 	}
+}
+
+// GetLimits gets the current limits for the global rate limiter.
+func (rl *RateLimit) GetLimits() (int64, int64) {
+	return rl.atomicReadBPS, rl.atomicWriteBPS
 }
 
 // SetLimits sets new limits for the global rate limiter.


### PR DESCRIPTION
Adding GetLimits() is needed to return the current limits for Sia's RenterSettings

Needed for build to pass on Sia's PR #3015